### PR TITLE
merge omg-js-testrunner to this repo

### DIFF
--- a/.circleci/ci_publish.sh
+++ b/.circleci/ci_publish.sh
@@ -1,0 +1,9 @@
+GIT_COMMIT_SHA=$(git rev-parse --short=7 HEAD)
+TEST_RUNNER_TAG=gcr.io/omisego-development/omg-js-testrunner:$GIT_COMMIT_SHA
+
+echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
+gcloud -q auth configure-docker
+
+docker build -t testrunner .
+docker tag testrunner $TEST_RUNNER_TAG
+docker push $TEST_RUNNER_TAG

--- a/.circleci/ci_publish.sh
+++ b/.circleci/ci_publish.sh
@@ -1,3 +1,6 @@
+set -e
+set -x
+
 GIT_COMMIT_SHA=$(git rev-parse --short=7 HEAD)
 TEST_RUNNER_TAG=gcr.io/omisego-development/omg-js-testrunner:$GIT_COMMIT_SHA
 

--- a/.circleci/ci_publish.sh
+++ b/.circleci/ci_publish.sh
@@ -1,11 +1,9 @@
+#!/bin/sh
+
 set -e
-set -x
 
 GIT_COMMIT_SHA=$(git rev-parse --short=7 HEAD)
 TEST_RUNNER_TAG=gcr.io/omisego-development/omg-js-testrunner:$GIT_COMMIT_SHA
-
-echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
-gcloud -q auth configure-docker
 
 docker build -t testrunner .
 docker tag testrunner $TEST_RUNNER_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -278,7 +278,8 @@ jobs:
             FAUCET_SALT: integration-tests
 
   publish_test_runner:
-    executor: metal
+    machine:
+      image: ubuntu-1604:201903-01
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -285,12 +285,14 @@ jobs:
       - run:
           name: publish to GCP container registry
           command: |
-            GIT_COMMIT_SHA=$(git rev-parse --short=7 HEAD)
-            TEST_RUNNER_TAG=gcr.io/omisego-development/omg-js-testrunner:$GIT_COMMIT_SHA
+            sh .circleci/ci_publish.sh
 
-            echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
-            gcloud -q auth configure-docker
+            # GIT_COMMIT_SHA=$(git rev-parse --short=7 HEAD)
+            # TEST_RUNNER_TAG=gcr.io/omisego-development/omg-js-testrunner:$GIT_COMMIT_SHA
 
-            docker build -t testrunner .
-            docker tag testrunner $TEST_RUNNER_TAG
-            docker push $TEST_RUNNER_TAG
+            # echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
+            # gcloud -q auth configure-docker
+
+            # docker build -t testrunner .
+            # docker tag testrunner $TEST_RUNNER_TAG
+            # docker push $TEST_RUNNER_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,59 +10,59 @@ workflows:
   version: 2
   build-master:
     jobs:
-      - unit-test:
-          filters:
-            branches:
-              only: master
-      - smoke-integration-test:
-          requires: [unit-test]
-          filters:
-            branches:
-              only: master
-      - baseline-integration-test:
-          requires: [unit-test]
-          filters:
-            branches:
-              only: master
-      - ife-integration-test:
-          requires: [unit-test]
-          filters:
-            branches:
-              only: master
-      - dependencies-audit:
-          filters:
-            branches:
-              only: master
+      # - unit-test:
+      #     filters:
+      #       branches:
+      #         only: master
+      # - smoke-integration-test:
+      #     requires: [unit-test]
+      #     filters:
+      #       branches:
+      #         only: master
+      # - baseline-integration-test:
+      #     requires: [unit-test]
+      #     filters:
+      #       branches:
+      #         only: master
+      # - ife-integration-test:
+      #     requires: [unit-test]
+      #     filters:
+      #       branches:
+      #         only: master
+      # - dependencies-audit:
+      #     filters:
+      #       branches:
+      #         only: master
       - publish_test_runner:
-          requires: [smoke-integration-test, baseline-integration-test, ife-integration-test]
+          # requires: [smoke-integration-test, baseline-integration-test, ife-integration-test]
           filters:
             branches:
-              only: master
-  build-other-branches:
-    jobs:
-      - unit-test:
-          filters:
-            branches:
-              ignore: master
-      - smoke-integration-test:
-          requires: [unit-test]
-          filters:
-            branches:
-              ignore: master
-      - baseline-integration-test:
-          requires: [unit-test]
-          filters:
-            branches:
-              ignore: master
-      - ife-integration-test:
-          requires: [unit-test]
-          filters:
-            branches:
-              ignore: master
-      - dependencies-audit:
-          filters:
-            branches:
-              ignore: master
+              only: boolafish/testrunner
+  # build-other-branches:
+  #   jobs:
+  #     - unit-test:
+  #         filters:
+  #           branches:
+  #             ignore: master
+  #     - smoke-integration-test:
+  #         requires: [unit-test]
+  #         filters:
+  #           branches:
+  #             ignore: master
+  #     - baseline-integration-test:
+  #         requires: [unit-test]
+  #         filters:
+  #           branches:
+  #             ignore: master
+  #     - ife-integration-test:
+  #         requires: [unit-test]
+  #         filters:
+  #           branches:
+  #             ignore: master
+  #     - dependencies-audit:
+  #         filters:
+  #           branches:
+  #             ignore: master
 
 commands:
   setup_integration_tests:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,59 +10,59 @@ workflows:
   version: 2
   build-master:
     jobs:
-      # - unit-test:
-      #     filters:
-      #       branches:
-      #         only: master
-      # - smoke-integration-test:
-      #     requires: [unit-test]
-      #     filters:
-      #       branches:
-      #         only: master
-      # - baseline-integration-test:
-      #     requires: [unit-test]
-      #     filters:
-      #       branches:
-      #         only: master
-      # - ife-integration-test:
-      #     requires: [unit-test]
-      #     filters:
-      #       branches:
-      #         only: master
-      # - dependencies-audit:
-      #     filters:
-      #       branches:
-      #         only: master
-      - publish_test_runner:
-          # requires: [smoke-integration-test, baseline-integration-test, ife-integration-test]
+      - unit-test:
           filters:
             branches:
-              only: boolafish/testrunner
-  # build-other-branches:
-  #   jobs:
-  #     - unit-test:
-  #         filters:
-  #           branches:
-  #             ignore: master
-  #     - smoke-integration-test:
-  #         requires: [unit-test]
-  #         filters:
-  #           branches:
-  #             ignore: master
-  #     - baseline-integration-test:
-  #         requires: [unit-test]
-  #         filters:
-  #           branches:
-  #             ignore: master
-  #     - ife-integration-test:
-  #         requires: [unit-test]
-  #         filters:
-  #           branches:
-  #             ignore: master
-  #     - dependencies-audit:
-  #         filters:
-  #           branches:
-  #             ignore: master
+              only: master
+      - smoke-integration-test:
+          requires: [unit-test]
+          filters:
+            branches:
+              only: master
+      - baseline-integration-test:
+          requires: [unit-test]
+          filters:
+            branches:
+              only: master
+      - ife-integration-test:
+          requires: [unit-test]
+          filters:
+            branches:
+              only: master
+      - dependencies-audit:
+          filters:
+            branches:
+              only: master
+      - publish_test_runner:
+          requires: [smoke-integration-test, baseline-integration-test, ife-integration-test]
+          filters:
+            branches:
+              only: master
+  build-other-branches:
+    jobs:
+      - unit-test:
+          filters:
+            branches:
+              ignore: master
+      - smoke-integration-test:
+          requires: [unit-test]
+          filters:
+            branches:
+              ignore: master
+      - baseline-integration-test:
+          requires: [unit-test]
+          filters:
+            branches:
+              ignore: master
+      - ife-integration-test:
+          requires: [unit-test]
+          filters:
+            branches:
+              ignore: master
+      - dependencies-audit:
+          filters:
+            branches:
+              ignore: master
 
 commands:
   setup_integration_tests:
@@ -291,13 +291,3 @@ jobs:
           name: publish to GCP container registry
           command: |
             sh .circleci/ci_publish.sh
-
-            # GIT_COMMIT_SHA=$(git rev-parse --short=7 HEAD)
-            # TEST_RUNNER_TAG=gcr.io/omisego-development/omg-js-testrunner:$GIT_COMMIT_SHA
-
-            # echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
-            # gcloud -q auth configure-docker
-
-            # docker build -t testrunner .
-            # docker tag testrunner $TEST_RUNNER_TAG
-            # docker push $TEST_RUNNER_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -283,6 +283,11 @@ jobs:
     steps:
       - checkout
       - run:
+          name: authenticate GCP with circle ci
+          command: |
+            echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
+            gcloud -q auth configure-docker
+      - run:
           name: publish to GCP container registry
           command: |
             sh .circleci/ci_publish.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -284,4 +284,13 @@ jobs:
       - checkout
       - run:
           name: publish to GCP container registry
-          command: sh .circleci/ci_publish.sh
+          command: |
+            GIT_COMMIT_SHA=$(git rev-parse --short=7 HEAD)
+            TEST_RUNNER_TAG=gcr.io/omisego-development/omg-js-testrunner:$GIT_COMMIT_SHA
+
+            echo $GCLOUD_SERVICE_KEY | gcloud auth activate-service-account --key-file=-
+            gcloud -q auth configure-docker
+
+            docker build -t testrunner .
+            docker tag testrunner $TEST_RUNNER_TAG
+            docker push $TEST_RUNNER_TAG

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,11 @@ workflows:
           filters:
             branches:
               only: master
+      - publish_test_runner:
+          requires: [smoke-integration-test, baseline-integration-test, ife-integration-test]
+          filters:
+            branches:
+              only: master
   build-other-branches:
     jobs:
       - unit-test:
@@ -271,3 +276,11 @@ jobs:
             MIN_AMOUNT_ERC20_PER_TEST: 20
             TOPUP_MULTIPLIER: 5
             FAUCET_SALT: integration-tests
+
+  publish_test_runner:
+    executor: metal
+    steps:
+      - checkout
+      - run:
+          name: publish to GCP container registry
+          command: sh .circleci/ci_publish.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+FROM node:12-alpine
+
+# Add other convenient dependency
+# For instace, we would like curl to trigger slack hook when using this docker to run test
+RUN apk update && apk add shadow git python g++ make curl
+
+COPY . /home/omg/
+
+RUN useradd -ms /bin/bash omg
+RUN chown -R omg:omg /home/omg/
+
+USER omg
+
+WORKDIR /home/omg/
+
+# WARNING: omg-js has a postinstall hook that will only be working if not running as root
+# https://stackoverflow.com/questions/47748075/npm-postinstall-not-running-in-docker
+# Since we are running as user: `omg` so it will be fine here
+RUN npm install


### PR DESCRIPTION
### Note

Merging the https://github.com/omgnetwork/omg-js-testrunner repo to here as the remaining function of that repo is a simple docker file that wraps omg-js.

- add docker file for omg-js
- publish the image as testrunner to GCP registry
- setup `GCLOUD_SERVICE_KEY` in circle CI env var

### Test
- example job: [link](https://app.circleci.com/pipelines/github/omgnetwork/omg-js/297/workflows/8e4609d2-ed77-4972-9931-578425bcb75a/jobs/876)
- example image: [link](https://console.cloud.google.com/gcr/images/omisego-development/GLOBAL/omg-js-testrunner@sha256:da3f0a861b3dae0fceeae9522993aa18137f9e30f262687d1e1ef562c44af6c1/details?tab=info&project=omisego-development)